### PR TITLE
feat: Add constant typesafe tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,7 @@ if (isOfType(user, schema)) {
 }
 ```
 
-When using TypeScript, you may even specify a generic type parameter, and use the function as a type guard. Also it is recommended to use the constant values
-exported by the validate-value instead of using string literals like above. These are type safe versions of these literals.
+When using TypeScript, you may even specify a generic type parameter, and use the function as a type guard. Also it is recommended to use the constant values exported by validate-value instead of the string literals as above, as they are the type-safe versions of these literals:
 
 ```typescript
 import { isTypeOf, value as v }

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ console.log(value.isValid(user));
 To verify that a variable is of a specific type, use the `isOfType` function. Hand over a value you would like to verify, and a JSON schema describing that type. The function returns `true` if the given variable matches the schema, and `false` if it doesn't:
 
 ```javascript
+const { isTypeOf } = require('validate-value'); 
+
 const user = {
   username: 'Jane Doe',
   password: 'secret'
@@ -113,9 +115,12 @@ if (isOfType(user, schema)) {
 }
 ```
 
-When using TypeScript, you may even specify a generic type parameter, and use the function as a type guard:
+When using TypeScript, you may even specify a generic type parameter, and use the function as a type guard. Also it is recommended to use the constant values
+exported by the validate-value instead of using string literals like above. These are type safe versions of these literals.
 
 ```typescript
+import { isTypeOf, value as v }
+
 interface User {
   username: string;
   password: string;
@@ -127,10 +132,10 @@ const user = {
 };
 
 const schema = {
-  type: 'object',
+  type: v.object,
   properties: {
-    username: { type: 'string' },
-    password: { type: 'string' }
+    username: { type: v.string },
+    password: { type: v.string }
   },
   additionalProperties: false,
   required: [ 'username', 'password' ]

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,5 @@
 import { isOfType } from './isOfType';
 import { Value } from './Value';
+import { values } from './values';
 
-export { isOfType, Value };
+export { isOfType, Value, values };

--- a/lib/values.ts
+++ b/lib/values.ts
@@ -1,0 +1,12 @@
+const values = {
+  string: 'string' as const,
+  number: 'number' as const,
+  integer: 'integer' as const,
+  boolean: 'boolean' as const,
+  object: 'object' as const,
+  array: 'array' as const,
+  null: 'null' as const,
+  any: 'any' as const
+};
+
+export { values };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     {
       "name": "Hannes Leutloff",
       "email": "hannes.leutloff@thenativeweb.io"
+    },
+    {
+      "name": "Alexander Kampf",
+      "email": "alexander.kampf@thenativeweb.io"
     }
   ],
   "main": "build/lib/index.js",


### PR DESCRIPTION
As discussed with @goloroden I added constant tokens which you can use in external JSON schemas in order to avoid the `string is not assignable to type 'object'` problem. 