### PR TITLE
feat: export type 'Format'

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
+import { Format } from 'ajv';
 import { getDefaultAjvInstance } from './getDefaultAjvInstance';
 import { isOfType } from './isOfType';
 import { JSONSchema7 as JsonSchema } from 'json-schema';
@@ -5,7 +6,11 @@ import { parse } from './parse';
 import { ParseError } from './ParseError';
 import { Parser } from './Parser';
 
-export type { JsonSchema };
+export type {
+  Format,
+  JsonSchema
+};
+
 export {
   getDefaultAjvInstance,
   isOfType,


### PR DESCRIPTION
When adding a custom format via

```ts
const customFormat = { ... };
ajvInstance.addFormat('customFormat', customFormat);
```

the variable `customFormat` must be of type `Format`. It would be nice to import this type from *validate-value*, otherwise one must install *ajv* in addition.