### PR TITLE
feat: Update to JsonSchema draft-2020-12.

### DIFF
--- a/lib/Parser.ts
+++ b/lib/Parser.ts
@@ -1,9 +1,10 @@
+import Ajv from 'ajv/dist/2020';
 import { getByInstancePath } from './getByInstancePath';
 import { getDefaultAjvInstance } from './getDefaultAjvInstance';
 import { JSONSchema7 } from 'json-schema';
 import { ParseError } from './ParseError';
 import { typeOf } from 'typedescriptor';
-import Ajv, { ValidateFunction } from 'ajv';
+import { ValidateFunction } from 'ajv';
 import { error, Result, value } from 'defekt';
 
 interface ParserOptions {

--- a/lib/getDefaultAjvInstance.ts
+++ b/lib/getDefaultAjvInstance.ts
@@ -1,5 +1,5 @@
 import addFormats from 'ajv-formats';
-import Ajv from 'ajv';
+import Ajv from 'ajv/dist/2020';
 
 const getDefaultAjvInstance = function (): Ajv {
   const defaultAjvInstance = new Ajv({


### PR DESCRIPTION
BREAKING CHANGE: Switched to version draft-202-12 of JSONSchema, find out more at https://ajv.js.org/json-schema.html#draft-2020-12

This resolves #393 and it resolves #394.
Adding the draft-2020-12 meta schema is not necessary with ajv's 2020-12 parser.